### PR TITLE
Window dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "1.0.0",
+  "version": "1.1.0-rc1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/processSnapsInBundle.js
+++ b/src/processSnapsInBundle.js
@@ -76,11 +76,24 @@ export default async function processSnapsInBundle(webpackBundle, {
   only,
   publicFolders,
   getRootElement,
+  viewport,
 }) {
+  const [ width, height ] = viewport.split('x').map((s) => parseInt(s, 10));
   const dom = new JSDOM(
     '<!DOCTYPE html><head></head><body></body></html>',
     {
       runScripts: 'outside-only',
+      beforeParse(win) {
+        const pxHeight = parseInt()
+        win.outerWidth = win.innerWidth = width;
+        win.outerHeight = win.innerHeight = height;
+        Object.defineProperties(win.screen, {
+          width: { value: width },
+          availWidth: { value: width },
+          height: { value: height },
+          availHeight: { value: height },
+        });
+      },
     }
   );
 

--- a/src/reactDOMRunner.js
+++ b/src/reactDOMRunner.js
@@ -23,18 +23,19 @@ export default async function reactDOMRunner({
 ) {
   async function readyHandler(bundleFile, logger = defaultLogger) {
     const cssBlocks = await Promise.all(stylesheets.map(loadCSSFile));
-    const { globalCSS, snapPayloads } = await processSnapsInBundle(bundleFile, {
-      globalCSS: cssBlocks.join('').replace(/\n/g, ''),
-      publicFolders,
-      getRootElement,
-      only,
-    });
-    if (!snapPayloads.length) {
-      throw new Error('No examples found');
-    }
 
     logger('Generating screenshots...');
     const results = await Promise.all(Object.keys(targets).map(async (name) => {
+      const { globalCSS, snapPayloads } = await processSnapsInBundle(bundleFile, {
+        globalCSS: cssBlocks.join('').replace(/\n/g, ''),
+        publicFolders,
+        getRootElement,
+        only,
+        viewport: targets[name].viewport,
+      });
+      if (!snapPayloads.length) {
+        throw new Error('No examples found');
+      }
       const result = await targets[name].execute({
         globalCSS,
         snapPayloads,


### PR DESCRIPTION
Since we render components in a jsdom environment, then send the payload
(html + css) to happo.io, we've basically executed javascript in a 0x0
sized window. Any code relying on window dimensions would have had to
work with that limitation. This isn't ideal, and we can quite easily fix
it by overriding dimensions with the ones we have specified in the
.happo.js config.

The downside with this approach is that we have to render all components
multiple times. One for each target. The upside is that any code relying
on window dimensions (innerWidth, outerWidth, screen.width, etc) will
generate the right markup.