### PR TITLE
Add babel-core as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "arrowParens": "always"
   },
   "dependencies": {
+    "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
     "babel-polyfill": "^6.26.0",
     "babel-preset-react": "^6.24.1",
@@ -74,5 +75,7 @@
     "react-dom": "^16.3.2",
     "rimraf": "^2.6.2"
   },
-  "peerDependencies": {}
+  "peerDependencies": {
+    "babel-core": "^6.26.3"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,9 +316,9 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@^6.0.0, babel-core@^6.26.0, babel-core@^6.26.3:
   version "6.26.3"
-  resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:
     babel-code-frame "^6.26.0"
     babel-generator "^6.26.0"


### PR DESCRIPTION
In a package where we use Happo, running `yarn` I saw the following warning:

> warning " > babel-loader@7.1.4" has unmet peer dependency "babel-core@6".

When running `yarn` in happo.io while investigating the above, I
saw the warnings:

> warning " > babel-loader@7.1.4" has unmet peer dependency "babel-core@6".
> warning " > babel-jest@22.4.3" has unmet peer dependency "babel-core@^6.0.0 || ^7.0.0-0".

This commit addresses the warnings by adding `babel-core` as a dependency.

I had considered making it a peer-dependency, but considering the amount of `babel-*` things in this repo, it seems nicer for end users to just add it here so they don't need to deal with it.