### PR TITLE
Wait for keypress on dev change detected

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     'no-console': 0,
     'arrow-parens': 0,
     'prefer-destructuring': 0,
+    'prefer-template': 0,
     'global-require': 0,
     'no-restricted-syntax': 0,
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
     "require-relative": "^0.8.7",
+    "supports-color": "^5.4.0",
     "webpack": "^3.5.5"
   },
   "devDependencies": {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -8,20 +8,13 @@ function withColorSupport(wrappedFunc) {
   }
   return (msg) => msg;
 }
-
 const red = withColorSupport((str) => `\x1b[31m${str}\x1b[0m`);
 const green = withColorSupport((str) => `\x1b[32m${str}\x1b[0m`);
 const underline = withColorSupport((str) => `\x1b[36m\x1b[4m${str}\x1b[0m`);
 
 export default class Logger {
   constructor() {
-    this.printed = '';
-    this.print = (str, isEdit) => {
-      process.stdout.write(str);
-      if (!isEdit) {
-        this.printed += str;
-      }
-    };
+    this.print = (str) => process.stdout.write(str);
     this.stderrPrint = (str) => process.stderr.write(str);
   }
 
@@ -40,11 +33,11 @@ export default class Logger {
   }
 
   start(msg) {
-    this.print(`${msg} `);
+    this.print(msg);
   }
 
   success(msg) {
-    this.print(green('✓'));
+    this.print(green(' ✓'));
     if (msg) {
       this.print(green(` ${msg}`));
     }
@@ -52,7 +45,7 @@ export default class Logger {
   }
 
   fail(msg) {
-    this.print(red('✗'));
+    this.print(red(' ✗'));
     if (msg) {
       this.print(red(` ${msg}`));
     }
@@ -62,27 +55,5 @@ export default class Logger {
   error(e) {
     this.stderrPrint(red(e.stack));
     this.stderrPrint('\n');
-  }
-
-  edit(msg, success) {
-    const print = () => {
-      this.print(`${msg} `, true);
-      if (success) {
-        this.print(green('✓'), true);
-      } else {
-        this.print(red('✗'), true);
-      }
-      this.print('\n', true);
-    };
-    let index;
-    if (typeof process.stdout.moveCursor === 'function') {
-      const lines = this.printed.split('\n').reverse();
-      index = lines.indexOf(msg);
-      process.stdout.moveCursor(0, -index);
-      print();
-      process.stdout.moveCursor(0, index);
-    } else {
-      print();
-    }
   }
 }

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,0 +1,45 @@
+export default class Logger {
+  constructor() {
+    this.print = (str) => process.stdout.write(str);
+    this.stderrPrint = (str) => process.stderr.write(str);
+  }
+
+  mute() {
+    this.print = () => null;
+    this.stderrPrint = () => null;
+  }
+
+  divider() {
+    this.info('-----------------------------------------');
+  }
+
+  info(msg) {
+    this.print(msg);
+    this.print('\n');
+  }
+
+  start(msg) {
+    this.print(msg);
+  }
+
+  success(msg) {
+    this.print(' ✓');
+    if (msg) {
+      this.print(` ${msg}`);
+    }
+    this.print('\n');
+  }
+
+  fail(msg) {
+    this.print(' ✗');
+    if (msg) {
+      this.print(` ${msg}`);
+    }
+    this.print('\n');
+  }
+
+  error(e) {
+    this.stderrPrint(e.stack);
+    this.stderrPrint('\n');
+  }
+}

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -33,11 +33,11 @@ export default class Logger {
   }
 
   start(msg) {
-    this.print(msg);
+    this.print(`${msg} `);
   }
 
   success(msg) {
-    this.print(green(' ✓'));
+    this.print(green('✓'));
     if (msg) {
       this.print(green(` ${msg}`));
     }
@@ -45,7 +45,7 @@ export default class Logger {
   }
 
   fail(msg) {
-    this.print(red(' ✗'));
+    this.print(red('✗'));
     if (msg) {
       this.print(red(` ${msg}`));
     }

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,3 +1,18 @@
+// https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color
+
+function red(str) {
+  return `\x1b[31m${str}\x1b[0m`;
+}
+
+function green(str) {
+  return `\x1b[32m${str}\x1b[0m`;
+}
+
+export function underline(str) {
+  // https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color
+  return `\x1b[36m\x1b[4m${str}\x1b[0m`;
+}
+
 export default class Logger {
   constructor() {
     this.print = (str) => process.stdout.write(str);
@@ -14,7 +29,7 @@ export default class Logger {
   }
 
   info(msg) {
-    this.print(msg);
+    this.print(msg.replace(/https?:\/\/[^ ]+/g, underline));
     this.print('\n');
   }
 
@@ -23,23 +38,23 @@ export default class Logger {
   }
 
   success(msg) {
-    this.print(' ✓');
+    this.print(green(' ✓'));
     if (msg) {
-      this.print(` ${msg}`);
+      this.print(green(` ${msg}`));
     }
     this.print('\n');
   }
 
   fail(msg) {
-    this.print(' ✗');
+    this.print(red(' ✗'));
     if (msg) {
-      this.print(` ${msg}`);
+      this.print(red(` ${msg}`));
     }
     this.print('\n');
   }
 
   error(e) {
-    this.stderrPrint(e.stack);
+    this.stderrPrint(red(e.stack));
     this.stderrPrint('\n');
   }
 }

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -8,13 +8,20 @@ function withColorSupport(wrappedFunc) {
   }
   return (msg) => msg;
 }
+
 const red = withColorSupport((str) => `\x1b[31m${str}\x1b[0m`);
 const green = withColorSupport((str) => `\x1b[32m${str}\x1b[0m`);
 const underline = withColorSupport((str) => `\x1b[36m\x1b[4m${str}\x1b[0m`);
 
 export default class Logger {
   constructor() {
-    this.print = (str) => process.stdout.write(str);
+    this.printed = '';
+    this.print = (str, isEdit) => {
+      process.stdout.write(str);
+      if (!isEdit) {
+        this.printed += str;
+      }
+    };
     this.stderrPrint = (str) => process.stderr.write(str);
   }
 
@@ -33,11 +40,11 @@ export default class Logger {
   }
 
   start(msg) {
-    this.print(msg);
+    this.print(`${msg} `);
   }
 
   success(msg) {
-    this.print(green(' ✓'));
+    this.print(green('✓'));
     if (msg) {
       this.print(green(` ${msg}`));
     }
@@ -45,7 +52,7 @@ export default class Logger {
   }
 
   fail(msg) {
-    this.print(red(' ✗'));
+    this.print(red('✗'));
     if (msg) {
       this.print(red(` ${msg}`));
     }
@@ -55,5 +62,27 @@ export default class Logger {
   error(e) {
     this.stderrPrint(red(e.stack));
     this.stderrPrint('\n');
+  }
+
+  edit(msg, success) {
+    const print = () => {
+      this.print(`${msg} `, true);
+      if (success) {
+        this.print(green('✓'), true);
+      } else {
+        this.print(red('✗'), true);
+      }
+      this.print('\n', true);
+    };
+    let index;
+    if (typeof process.stdout.moveCursor === 'function') {
+      const lines = this.printed.split('\n').reverse();
+      index = lines.indexOf(msg);
+      process.stdout.moveCursor(0, -index);
+      print();
+      process.stdout.moveCursor(0, index);
+    } else {
+      print();
+    }
   }
 }

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,17 +1,16 @@
+import supportsColor from 'supports-color';
+
 // https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color
 
-function red(str) {
-  return `\x1b[31m${str}\x1b[0m`;
+function withColorSupport(wrappedFunc) {
+  if (supportsColor.stdout && supportsColor.stderr) {
+    return wrappedFunc;
+  }
+  return (msg) => msg;
 }
-
-function green(str) {
-  return `\x1b[32m${str}\x1b[0m`;
-}
-
-export function underline(str) {
-  // https://stackoverflow.com/questions/9781218/how-to-change-node-jss-console-font-color
-  return `\x1b[36m\x1b[4m${str}\x1b[0m`;
-}
+const red = withColorSupport((str) => `\x1b[31m${str}\x1b[0m`);
+const green = withColorSupport((str) => `\x1b[32m${str}\x1b[0m`);
+const underline = withColorSupport((str) => `\x1b[36m\x1b[4m${str}\x1b[0m`);
 
 export default class Logger {
   constructor() {

--- a/src/MultipleErrors.js
+++ b/src/MultipleErrors.js
@@ -1,0 +1,7 @@
+export default class MultipleErrors extends Error {
+  constructor(errors) {
+    super(`Found ${errors.length} error(s)`);
+    this.stack = this.message + '\n\n' +
+      errors.map(({ stack }) => stack).join('\n----------------\n');
+  }
+}

--- a/src/RemoteBrowserTarget.js
+++ b/src/RemoteBrowserTarget.js
@@ -24,7 +24,7 @@ export default class RemoteBrowserTarget {
     this.viewport = viewport;
   }
 
-  async execute({ globalCSS, snapPayloads, apiKey, apiSecret, endpoint, logger }) {
+  async execute({ globalCSS, snapPayloads, apiKey, apiSecret, endpoint }) {
     const { requestId } = await makeRequest(
       {
         url: `${endpoint}/api/snap-requests`,
@@ -41,7 +41,6 @@ export default class RemoteBrowserTarget {
       },
       { apiKey, apiSecret },
     );
-    logger(`Waiting for ${this.browserName} results (ID=${requestId})...`);
     return waitFor({ requestId, endpoint, apiKey, apiSecret });
   }
 }

--- a/src/WrappedError.js
+++ b/src/WrappedError.js
@@ -1,0 +1,14 @@
+// Inspired by https://stackoverflow.com/questions/42754270/re-throwing-exception-in-nodejs-and-not-losing-stack-trace
+export default class WrappedError extends Error {
+  constructor(message, error) {
+    super(message);
+    this.original = error;
+    Error.captureStackTrace(this, this.constructor);
+    const newLines = this.message.split(/\n/).length;
+    const diff = this.stack
+      .split('\n')
+      .slice(0, newLines + 1)
+      .join('\n');
+    this.stack = `${diff}\n${error.stack}`;
+  }
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,10 +2,11 @@
 
 import 'babel-polyfill';
 
+import Logger from './Logger';
 import executeCli from './executeCli';
 
 process.on('unhandledRejection', (error) => {
-  console.error(error.stack);
+  new Logger().error(error);
   process.exit(1);
 });
 

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,10 +1,12 @@
+import Logger from '../Logger';
 import domRunner from '../domRunner';
 import uploadReport from '../uploadReport';
 
 export default async function runCommand(sha, config, { only, link, message }) {
+  const logger = new Logger();
   const { apiKey, apiSecret, endpoint } = config;
   const snaps = await domRunner(config, { only });
-  console.log(`Uploading report for ${sha}...`);
+  logger.start(`Uploading report for ${sha}...`);
   const { url } = await uploadReport({
     snaps,
     sha,
@@ -14,6 +16,7 @@ export default async function runCommand(sha, config, { only, link, message }) {
     link,
     message,
   });
-  console.log(`View results at ${url}`);
-  console.log(`Done ${sha}`);
+  logger.success();
+  logger.info(`View results at ${url}`);
+  logger.info(`Done ${sha}`);
 }

--- a/src/createDynamicEntryPoint.js
+++ b/src/createDynamicEntryPoint.js
@@ -9,15 +9,14 @@ import findTestFiles from './findTestFiles';
 export default function createDynamicEntryPoint({ setupScript, include, only, type }) {
   return findTestFiles(include).then((files) => {
     const filePartOfOnly = only ? only.split('#')[0] : undefined;
+    const fileStrings = files
+      .filter((f) => (filePartOfOnly ? f.includes(filePartOfOnly) : true))
+      .map((file) => `window.snaps['${file}'] = require('${path.join(process.cwd(), file)}');`);
     const strings = [
       setupScript ? `require('${setupScript}');` : '',
       'window.snaps = {};',
       `window.happoFlags = { only: ${JSON.stringify(only)} }`,
-    ].concat(
-      files
-        .filter((f) => (filePartOfOnly ? f.includes(filePartOfOnly) : true))
-        .map((file) => `window.snaps['${file}'] = require('${path.join(process.cwd(), file)}');`),
-    );
+    ].concat(fileStrings);
     if (type === 'react') {
       const pathToReactDom = requireRelative.resolve('react-dom', process.cwd());
       strings.push(
@@ -28,20 +27,22 @@ export default function createDynamicEntryPoint({ setupScript, include, only, ty
       `.trim(),
       );
     } else {
-      strings.push(`
+      strings.push(
+        `
         window.happoRender = (html, { rootElement }) => {
           rootElement.innerHTML = html;
           return rootElement;
         };
-      `.trim());
+      `.trim(),
+      );
     }
     strings.push('window.onBundleReady();');
-    const tmpFile = path.join(
+    const entryFile = path.join(
       os.tmpdir(),
       `happo-entry-${type}-${Buffer.from(process.cwd()).toString('base64')}.js`,
     );
 
-    fs.writeFileSync(tmpFile, strings.join('\n'));
-    return tmpFile;
+    fs.writeFileSync(entryFile, strings.join('\n'));
+    return { entryFile, numberOfFilesProcessed: fileStrings.length };
   });
 }

--- a/src/createWebpackBundle.js
+++ b/src/createWebpackBundle.js
@@ -3,6 +3,8 @@ import path from 'path';
 
 import webpack from 'webpack';
 
+import Logger from './Logger';
+
 function generateBaseConfig(entry, type) {
   const outFile = `happo-bundle-${type}-${Buffer.from(process.cwd()).toString('base64')}.js`;
   const babelLoader = require.resolve('babel-loader');
@@ -51,7 +53,7 @@ export default function createWebpackBundle(
     let hash;
     compiler.watch({}, (err, stats) => {
       if (err) {
-        console.log(err);
+        new Logger().error(err);
       } else if (hash !== stats.hash) {
         hash = stats.hash;
         onBuildReady(bundleFilePath);

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -137,6 +137,7 @@ export default async function domRunner(
             if (waitPromise.cancelled) {
               return;
             }
+            logger.divider();
           } else {
             logger.success();
           }

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -35,7 +35,8 @@ async function generateScreenshots(
   const cssBlocks = await Promise.all(stylesheets.map(loadCSSFile));
 
   const targetNames = Object.keys(targets);
-  logger.start(`Generating screenshots for ${targetNames.join(', ')}...`);
+  const tl = targetNames.length;
+  logger.info(`Generating screenshots in ${tl} target${tl > 1 ? 's' : ''}...`);
   try {
     const results = await Promise.all(
       targetNames.map(async (name) => {
@@ -64,10 +65,11 @@ async function generateScreenshots(
           apiSecret,
           endpoint,
         });
+        logger.start(`  - ${name}`);
+        logger.success();
         return { name, result };
       }),
     );
-    logger.success();
     return constructReport(results);
   } catch (e) {
     logger.fail();

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -35,7 +35,7 @@ async function generateScreenshots(
   const cssBlocks = await Promise.all(stylesheets.map(loadCSSFile));
 
   const targetNames = Object.keys(targets);
-  logger.start(`Generating screenshots for ${targetNames.join(', ')}...`);
+  logger.info('Generating screenshots...');
   try {
     const results = await Promise.all(
       targetNames.map(async (name) => {
@@ -57,6 +57,7 @@ async function generateScreenshots(
           throw new MultipleErrors(errors);
         }
 
+        logger.info(`Waiting for ${name}...`);
         const result = await targets[name].execute({
           globalCSS,
           snapPayloads,
@@ -64,10 +65,11 @@ async function generateScreenshots(
           apiSecret,
           endpoint,
         });
+        logger.edit(`Waiting for ${name}...`, true);
         return { name, result };
       }),
     );
-    logger.success();
+    logger.edit('Generating screenshots...', true);
     return constructReport(results);
   } catch (e) {
     logger.fail();

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -35,7 +35,7 @@ async function generateScreenshots(
   const cssBlocks = await Promise.all(stylesheets.map(loadCSSFile));
 
   const targetNames = Object.keys(targets);
-  logger.info('Generating screenshots...');
+  logger.start(`Generating screenshots for ${targetNames.join(', ')}...`);
   try {
     const results = await Promise.all(
       targetNames.map(async (name) => {
@@ -57,7 +57,6 @@ async function generateScreenshots(
           throw new MultipleErrors(errors);
         }
 
-        logger.info(`Waiting for ${name}...`);
         const result = await targets[name].execute({
           globalCSS,
           snapPayloads,
@@ -65,11 +64,10 @@ async function generateScreenshots(
           apiSecret,
           endpoint,
         });
-        logger.edit(`Waiting for ${name}...`, true);
         return { name, result };
       }),
     );
-    logger.edit('Generating screenshots...', true);
+    logger.success();
     return constructReport(results);
   } catch (e) {
     logger.fail();

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -1,6 +1,7 @@
 import commander from 'commander';
 
 import { configFile } from './DEFAULTS';
+import Logger from './Logger';
 import compareReportsCommand from './commands/compareReports';
 import devCommand from './commands/dev';
 import generateDevSha from './generateDevSha';
@@ -24,7 +25,7 @@ commander
   .action(async (sha) => {
     let usedSha = sha || generateDevSha();
     if (!sha) {
-      console.log(`No [sha] provided. A temporary one will be used in place: "${usedSha}".`);
+      new Logger().info(`No [sha] provided. A temporary one will be used in place: "${usedSha}".`);
     }
     if (commander.only) {
       usedSha = `${usedSha}-${commander.only}`;
@@ -65,7 +66,7 @@ commander
       message: commander.message,
       author: commander.author,
     });
-    console.log(result.summary);
+    new Logger().info(result.summary);
     if (result.equal) {
       process.exit(0);
     } else {

--- a/src/getComponentNameFromFileName.js
+++ b/src/getComponentNameFromFileName.js
@@ -4,7 +4,6 @@ const DIRECTORY_PATTERN = /([\w-_]+)\/\w+\.jsx?$/;
 export default function getComponentNameFromFileName(fileName) {
   const match = fileName.match(SUFFIX_PATTERN) || fileName.match(DIRECTORY_PATTERN);
   if (!match) {
-    console.log('no match', fileName);
     // This is unexpected, but we can at least fall back to the file name.
     return fileName;
   }

--- a/src/processSnapsInBundle.js
+++ b/src/processSnapsInBundle.js
@@ -75,8 +75,8 @@ async function processVariants({
     try {
       await renderExample(dom, exampleRenderFunc);
     } catch (e) {
-      throw new WrappedError(
-        `Error in ${fileName}:\nFailed to render component "${component}", variant "${variant}"`,
+      return new WrappedError(
+        `Failed to render component "${component}", variant "${variant}" in ${fileName}`,
         e,
       );
     }

--- a/src/processSnapsInBundle.js
+++ b/src/processSnapsInBundle.js
@@ -40,8 +40,7 @@ async function renderExample(dom, exampleRenderFunc) {
   rootElement.setAttribute('id', ROOT_ELEMENT_ID);
   doc.body.appendChild(rootElement);
 
-  const renderInDom = (renderResult) =>
-    dom.window.happoRender(renderResult, { rootElement });
+  const renderInDom = (renderResult) => dom.window.happoRender(renderResult, { rootElement });
 
   const result = exampleRenderFunc(renderInDom);
   if (result && typeof result.then === 'function') {
@@ -75,10 +74,16 @@ async function processVariants({
     try {
       await renderExample(dom, exampleRenderFunc);
     } catch (e) {
-      console.error(
+      const wrappedError = new Error(
         `Error in ${fileName}:\nFailed to render component "${component}", variant "${variant}"`,
       );
-      throw e;
+      wrappedError.original = e;
+      const diff = wrappedError.stack
+        .split('\n')
+        .slice(0, 3)
+        .join('\n');
+      wrappedError.stack = `${diff}\n${e.stack}`;
+      throw wrappedError;
     }
 
     if (publicFolders && publicFolders.length) {

--- a/src/processSnapsInBundle.js
+++ b/src/processSnapsInBundle.js
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 
+import WrappedError from './WrappedError';
 import createHash from './createHash';
 import extractCSS from './extractCSS';
 import getComponentNameFromFileName from './getComponentNameFromFileName';
@@ -74,16 +75,10 @@ async function processVariants({
     try {
       await renderExample(dom, exampleRenderFunc);
     } catch (e) {
-      const wrappedError = new Error(
+      throw new WrappedError(
         `Error in ${fileName}:\nFailed to render component "${component}", variant "${variant}"`,
+        e,
       );
-      wrappedError.original = e;
-      const diff = wrappedError.stack
-        .split('\n')
-        .slice(0, 3)
-        .join('\n');
-      wrappedError.stack = `${diff}\n${e.stack}`;
-      throw wrappedError;
     }
 
     if (publicFolders && publicFolders.length) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,33 +316,9 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@^6.0.0, babel-core@^6.26.0, babel-core@^6.26.3:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-generator "^6.26.0"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    convert-source-map "^1.5.1"
-    debug "^2.6.9"
-    json5 "^0.5.1"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    path-is-absolute "^1.0.1"
-    private "^0.1.8"
-    slash "^1.0.0"
-    source-map "^0.5.7"
-
-babel-core@^6.26.3:
-  version "6.26.3"
-  resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:
     babel-code-frame "^6.26.0"
     babel-generator "^6.26.0"
@@ -4720,7 +4696,7 @@ supports-color@^4.2.1:
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:


### PR DESCRIPTION
Instead of automatically trying to generate screenshots every time the
user saves a file, we now wait for a keypress before we continue. This
is better because it allows you to work on the file for a while before
committing to generate the screenshots. Often times, there will be build
failures before you can continue anyway.