### PR TITLE
Use temporary pull-request token for PRs from forks

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -36,6 +36,12 @@ run-happo() {
     eval "$INSTALL_CMD"
   fi
 
+  echo "ENV in run-happo function of happo-ci script (for sha ${SHA})"
+  echo "PREVIOUS_SHA: ${PREVIOUS_SHA}"
+  echo "CURRENT_SHA: ${CURRENT_SHA}"
+  echo "CHANGE_URL: ${CHANGE_URL}"
+  echo "INSTALL_CMD: ${INSTALL_CMD}"
+
   if [ -f "${NPM_BIN}/happo" ]; then
     "$NPM_BIN"/happo run "$SHA" \
     --link "${CHANGE_URL}" \

--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -36,12 +36,6 @@ run-happo() {
     eval "$INSTALL_CMD"
   fi
 
-  echo "ENV in run-happo function of happo-ci script (for sha ${SHA})"
-  echo "PREVIOUS_SHA: ${PREVIOUS_SHA}"
-  echo "CURRENT_SHA: ${CURRENT_SHA}"
-  echo "CHANGE_URL: ${CHANGE_URL}"
-  echo "INSTALL_CMD: ${INSTALL_CMD}"
-
   if [ -f "${NPM_BIN}/happo" ]; then
     "$NPM_BIN"/happo run "$SHA" \
     --link "${CHANGE_URL}" \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "1.4.0",
+  "version": "1.5.0-rc.1",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "1.5.0-rc.1",
+  "version": "1.5.0-rc.2",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo.io",
-  "version": "1.5.0-rc.2",
+  "version": "1.5.0",
   "description": "Visual diffing for UI components",
   "main": "./build/index.js",
   "bin": {

--- a/src/executeCli.js
+++ b/src/executeCli.js
@@ -30,7 +30,7 @@ commander
     if (commander.only) {
       usedSha = `${usedSha}-${commander.only}`;
     }
-    await runCommand(usedSha, loadUserConfig(commander.config), {
+    await runCommand(usedSha, await loadUserConfig(commander.config), {
       only: commander.only,
       link: commander.link,
       message: commander.message,
@@ -41,7 +41,7 @@ commander
   .command('dev')
   .description('start dev mode')
   .action(async () => {
-    await devCommand(loadUserConfig(commander.config), {
+    await devCommand(await loadUserConfig(commander.config), {
       only: commander.only,
     });
   });
@@ -50,7 +50,7 @@ commander
   .command('has-report <sha>')
   .description('check if there is a report for a specific sha')
   .action(async (sha) => {
-    if (await hasReportCommand(sha, loadUserConfig(commander.config))) {
+    if (await hasReportCommand(sha, await loadUserConfig(commander.config))) {
       process.exit(0);
     } else {
       process.exit(1);
@@ -61,7 +61,7 @@ commander
   .command('compare <sha1> <sha2>')
   .description('compare reports for two different shas')
   .action(async (sha1, sha2) => {
-    const result = await compareReportsCommand(sha1, sha2, loadUserConfig(commander.config), {
+    const result = await compareReportsCommand(sha1, sha2, await loadUserConfig(commander.config), {
       link: commander.link,
       message: commander.message,
       author: commander.author,

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -31,7 +31,6 @@ async function getPullRequestSecret({ endpoint }, env) {
 }
 
 export default async function loadUserConfig(pathToConfigFile, env = process.env) {
-  console.log('ENV inside loadUserConfig', env);
   const { CHANGE_URL } = env;
 
   const config = load(pathToConfigFile);

--- a/src/loadUserConfig.js
+++ b/src/loadUserConfig.js
@@ -31,6 +31,7 @@ async function getPullRequestSecret({ endpoint }, env) {
 }
 
 export default async function loadUserConfig(pathToConfigFile, env = process.env) {
+  console.log('ENV inside loadUserConfig', env);
   const { CHANGE_URL } = env;
 
   const config = load(pathToConfigFile);

--- a/src/processSnapsInBundle.js
+++ b/src/processSnapsInBundle.js
@@ -144,7 +144,13 @@ export default async function processSnapsInBundle(
   const onlyComponent = only ? only.split('#')[1] : undefined;
 
   await queued(Object.keys(dom.window.snaps), async (fileName) => {
-    const objectOrArray = dom.window.snaps[fileName];
+    let objectOrArray = dom.window.snaps[fileName];
+    const keys = Object.keys(objectOrArray);
+    if (keys.includes('default') && Array.isArray(objectOrArray.default)) {
+      // The default export is an array. Treat this as a file which has
+      // generated examples.
+      objectOrArray = objectOrArray.default;
+    }
     if (Array.isArray(objectOrArray)) {
       await queued(objectOrArray, async ({ component, variants }) => {
         const processedVariants = await processVariants({

--- a/test/integrations/examples/Bar-react-happo.js
+++ b/test/integrations/examples/Bar-react-happo.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default [
+  {
+    component: 'Bar',
+    variants: {
+      one: () => <div>one</div>,
+      two: () => <div>two</div>,
+    },
+  },
+];

--- a/test/integrations/react-test.js
+++ b/test/integrations/react-test.js
@@ -23,6 +23,20 @@ it('produces the right html', async () => {
   await subject();
   expect(config.targets.chrome.snapPayloads).toEqual([
     {
+      component: 'Bar',
+      css: '',
+      hash: 'a2e67882fb930e9fa82a3bb3e442ca23',
+      html: '<div>one</div>',
+      variant: 'one',
+    },
+    {
+      component: 'Bar',
+      css: '',
+      hash: 'e365ab0df4cb21bba69c2c34d8162127',
+      html: '<div>two</div>',
+      variant: 'two',
+    },
+    {
       component: 'Foo-react',
       css: '',
       hash: '4a799dea4acaa048759c5904ff84a771',

--- a/test/loadUserConfig-test.js
+++ b/test/loadUserConfig-test.js
@@ -1,25 +1,27 @@
 import requireRelative from 'require-relative';
+import request from 'request-promise-native';
 
 import RemoteBrowserTarget from '../src/RemoteBrowserTarget';
 import loadUserConfig from '../src/loadUserConfig';
 
+jest.mock('request-promise-native');
 jest.mock('require-relative');
 
-it('yells if api tokens are missing', () => {
+it('yells if api tokens are missing', async () => {
   requireRelative.mockImplementation(() => ({}));
-  expect(() => loadUserConfig('bogus')).toThrowError(/You need an `apiKey`/);
+  await expect(loadUserConfig('bogus')).rejects.toThrow(/You need an `apiKey`/);
 });
 
-it('yells if targets are missing', () => {
+it('yells if targets are missing', async () => {
   requireRelative.mockImplementation(() => ({
     apiKey: '1',
     apiSecret: '2',
     targets: {},
   }));
-  expect(() => loadUserConfig('bogus')).toThrowError(/You need at least one target/);
+  await expect(loadUserConfig('bogus')).rejects.toThrow(/You need at least one target/);
 });
 
-it('does not yell if all required things are in place', () => {
+it('does not yell if all required things are in place', async () => {
   requireRelative.mockImplementation(() => ({
     apiKey: '1',
     apiSecret: '2',
@@ -27,10 +29,39 @@ it('does not yell if all required things are in place', () => {
       firefox: new RemoteBrowserTarget('firefox', { viewport: '800x600' }),
     },
   }));
-  expect(() => loadUserConfig('bogus')).not.toThrowError();
-  expect(loadUserConfig('bogus').apiKey).toEqual('1');
-  expect(loadUserConfig('bogus').apiSecret).toEqual('2');
-  expect(loadUserConfig('bogus').targets).toEqual({
+  const config = await loadUserConfig('bogus');
+  expect(config.apiKey).toEqual('1');
+  expect(config.apiSecret).toEqual('2');
+  expect(config.targets).toEqual({
     firefox: new RemoteBrowserTarget('firefox', { viewport: '800x600' }),
+  });
+});
+
+describe('when CHANGE_URL is defined', () => {
+  beforeEach(() => {
+    requireRelative.mockImplementation(() => ({
+      targets: {
+        firefox: new RemoteBrowserTarget('firefox', { viewport: '800x600' }),
+      },
+    }));
+    request.mockImplementation(() => Promise.resolve({ secret: 'yay' }));
+  });
+
+  it('grabs a temporary secret', async () => {
+    const config = await loadUserConfig('bogus', { CHANGE_URL: 'foo.bar' });
+    expect(config.apiKey).toEqual('foo.bar');
+    expect(config.apiSecret).toEqual('yay');
+  });
+
+  describe('when the API has an error response', () => {
+    beforeEach(() => {
+      request.mockImplementation(() => Promise.reject(new Error('nope')));
+    });
+
+    it('yells', async () => {
+      await expect(loadUserConfig('bogus', { CHANGE_URL: 'foo.bar' })).rejects.toThrow(
+        /Failed to obtain temporary pull-request token/,
+      );
+    });
   });
 });


### PR DESCRIPTION
Providing secret environment variables in CI to forks is tricky. Most CI
environments, such as Travis, explicitly disable secrets when it detects
that a run is triggered on a fork of a repo.
https://github.com/travis-ci/travis-ci/issues/1946

To work around this, I've adopted a separate auth mechanism for happo.io
for outside pull requests. Instead of requiring an apiKey and an
apiSecret, we use temporary tokens, pulled from the Happo API if we
detect that we're in a fork (keys are missing). These tokens are much
more limited in scope compared to the regular API tokens. We're
basically allowing them to generate reports for the PR in question, and
only for a limited time.