### PR TITLE
Add `jsdomOptions` as allowed parameter to `.happo.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,22 @@ module.exports = {
 }
 ```
 
+### `jsdomOptions`
+
+Happo uses jsdom internally. By default, it provides sane defaults to
+the `JSDOM` constructor. See [processSnapsInBundle.js](src/processSnapsInBundle.js).
+You can override any options here but your mileage may vary. In particular if you are
+using `localStorage` in your components, you will have to set the `url` option. See
+https://github.com/jsdom/jsdom#simple-options.
+
+```js
+module.exports = {
+  jsdomOptions: {
+    url: 'http://127.0.0.1',  // Your expected URL
+  }
+}
+```
+
 ## Command-Line-Interface (CLI)
 
 While you are most likely getting most value from the ready-made CI integration
@@ -719,4 +735,3 @@ data as props instead of relying on the component to compute it itself.
 
 Yes, either through providing an external stylesheet in the `stylesheets`
 config or by injecting them as inline base64 urls through a `happoSetup` file.
-

--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -28,7 +28,17 @@ function waitForAnyKey() {
 }
 
 async function generateScreenshots(
-  { apiKey, apiSecret, stylesheets, endpoint, targets, publicFolders, getRootElement, only },
+  {
+    apiKey,
+    apiSecret,
+    stylesheets,
+    endpoint,
+    targets,
+    publicFolders,
+    getRootElement,
+    only,
+    jsdomOptions,
+  },
   bundleFile,
   logger,
 ) {
@@ -46,6 +56,7 @@ async function generateScreenshots(
           getRootElement,
           only,
           viewport: targets[name].viewport,
+          jsdomOptions,
         });
         if (!snapPayloads.length) {
           throw new Error('No examples found');
@@ -92,6 +103,7 @@ export default async function domRunner(
     type,
     plugins,
     tmpdir,
+    jsdomOptions,
   },
   { only, onReady },
 ) {
@@ -104,6 +116,7 @@ export default async function domRunner(
     publicFolders,
     getRootElement,
     only,
+    jsdomOptions,
   });
   const logger = new Logger();
   logger.start('Reading files...');

--- a/src/processSnapsInBundle.js
+++ b/src/processSnapsInBundle.js
@@ -102,7 +102,7 @@ async function processVariants({
 
 export default async function processSnapsInBundle(
   webpackBundle,
-  { globalCSS, only, publicFolders, getRootElement, viewport },
+  { globalCSS, only, publicFolders, getRootElement, viewport, jsdomOptions },
 ) {
   const [width, height] = viewport.split('x').map((s) => parseInt(s, 10));
   const dom = new JSDOM(
@@ -116,7 +116,7 @@ export default async function processSnapsInBundle(
         </body>
       </html>
     `.trim(),
-    {
+    Object.assign({
       runScripts: 'dangerously',
       resources: 'usable',
       beforeParse(win) {
@@ -131,7 +131,7 @@ export default async function processSnapsInBundle(
         win.requestAnimationFrame = (callback) => setTimeout(callback, 0);
         win.cancelAnimationFrame = () => {};
       },
-    },
+    }, jsdomOptions),
   );
 
   await new Promise((resolve) => {


### PR DESCRIPTION
Allows users to override their `JSDOM` constructor options
in case they need to so something special with their window
runner.

In particular this is useful for getting around a security issue
from `jsdom` that expects users to define a domain to run on
when accessing `localStorage`.

I need advice on how to test this better and am open for
other suggestions.