### PR TITLE
Inline images in srcset attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "request": "^2.85.0",
     "request-promise-native": "^1.0.5",
     "require-relative": "^0.8.7",
+    "string.prototype.matchall": "^3.0.0",
     "supports-color": "^5.4.0"
   },
   "devDependencies": {

--- a/test/inlineResources-test.js
+++ b/test/inlineResources-test.js
@@ -69,6 +69,74 @@ it('inlines multiple images', () => {
   );
 });
 
+it('inlines srcset attributes', () => {
+  const dom = createDom(`
+    <img src="/1x1.jpg" srcset="/1x1.jpg 197w, /1x1.png 393w, http://dns/1.png 600w">
+  `);
+  expect(inlineResources(dom, { publicFolders })).toEqual(
+    `
+    <img src="${jpgb64}" srcset="${jpgb64} 197w, ${pngb64} 393w, http://dns/1.png 600w">
+  `.trim(),
+  );
+});
+
+it('handles invalid srcset attributes', () => {
+  const dom = createDom(`
+    <img srcset="    ">
+  `);
+  expect(inlineResources(dom, { publicFolders })).toEqual(
+    `
+    <img srcset="">
+  `.trim(),
+  );
+});
+
+it('handles single-url srcsets', () => {
+  const dom = createDom(`
+    <img srcset="/1x1.png">
+  `);
+  expect(inlineResources(dom, { publicFolders })).toEqual(
+    `
+    <img srcset="${pngb64}">
+  `.trim(),
+  );
+});
+
+it('handles single-url srcsets with external urls', () => {
+  const dom = createDom(`
+    <img srcset="http://foo/1.png">
+  `);
+  expect(inlineResources(dom, { publicFolders })).toEqual(
+    `
+    <img srcset="http://foo/1.png">
+  `.trim(),
+  );
+});
+
+it('handles srcset that can not be found', () => {
+  const dom = createDom(`
+    <img srcset="/f1,2,3.png 100w, /f1,3.png 200w">
+  `);
+  expect(inlineResources(dom, { publicFolders })).toEqual(
+    `
+    <img srcset="/f1,2,3.png 100w, /f1,3.png 200w">
+  `.trim(),
+  );
+});
+
+it('handles srcset with plenty of whitespace', () => {
+  const dom = createDom(`
+    <img srcset="
+      /1x1.png    100w,
+      /f1,3.png   200w"
+    >
+  `);
+  expect(inlineResources(dom, { publicFolders })).toEqual(
+    `
+    <img srcset="${pngb64}    100w, /f1,3.png   200w">
+  `.trim(),
+  );
+});
 it('leaves images that can not be found alone', () => {
   const dom = createDom('<img src="/2x2.png">');
   expect(inlineResources(dom, { publicFolders })).toEqual('<img src="/2x2.png">');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1848,6 +1848,16 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
 es-abstract@^1.5.1, es-abstract@^1.7.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
@@ -2503,6 +2513,10 @@ has-flag@^1.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -4550,6 +4564,12 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexp.prototype.flags@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz#6b30724e306a27833eeb171b66ac8890ba37e41c"
+  dependencies:
+    define-properties "^1.1.2"
+
 regexpp@^1.0.1:
   version "1.1.0"
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
@@ -5061,6 +5081,16 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string.prototype.matchall@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-3.0.0.tgz#66f4d8dd5c6c6cea4dffb55ec5f3184a8dd0dd59"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    regexp.prototype.flags "^1.2.0"
 
 string_decoder@^1.0.0, string_decoder@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Up until now, we've only been inlining images found in the `src`
attribute of an image. By also including `srcset` we can prevent
examples with broken images.

I found this while working on a PR to add Happo testing to Gatsby.
https://github.com/trotzig/gatsby/commit/86b177bd020e713662540a8c38b51ab69dc504f2