### PR TITLE
Avoid touching lockfiles when installing dependencies

### DIFF
--- a/bin/happo-ci
+++ b/bin/happo-ci
@@ -16,9 +16,11 @@ echo "CHANGE_URL: ${CHANGE_URL}"
 echo "INSTALL_CMD: ${INSTALL_CMD}"
 
 NPM_CLIENT="npm"
+NPM_CLIENT_FLAGS="--no-save"
 if [ -f "yarn.lock" ]; then
   echo "Detected yarn.lock - using yarn to install dependencies"
   NPM_CLIENT="yarn"
+  NPM_CLIENT_FLAGS="--pure-lockfile"
 fi
 
 run-happo() {
@@ -30,7 +32,7 @@ run-happo() {
   # git history)
   if [ -z "$INSTALL_CMD" ]; then
     # Run yarn/npm install
-    ${NPM_CLIENT} install
+    ${NPM_CLIENT} install ${NPM_CLIENT_FLAGS}
   else
     # Run custom install command(s)
     eval "$INSTALL_CMD"


### PR DESCRIPTION
A customer reported that the happo-ci script failed intermittently due
to package-lock.json being modified as part of the `npm install`.

  error: Your local changes to the following files would be overwritten by checkout:
      package-lock.json
  Please, commit your changes or stash them before you can switch branches.

Yarn has a --pure-lockfile flag to prevent yarn.lock from being touched.
https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-pure-lockfile

Finding a flag for npm was trickier. I think the real fix is to use `npm
ci`, https://docs.npmjs.com/cli/ci. But I don't want to introduce that
change right now as I know too little of the side-effects. Instead, the
--no-save flag seems to do the trick, as verified locally and in this
npm issue:
https://github.com/npm/npm/issues/17761