### PR TITLE
Improve getComponentFromFilename for /\.tsx?/ files

### DIFF
--- a/src/getComponentNameFromFileName.js
+++ b/src/getComponentNameFromFileName.js
@@ -1,5 +1,5 @@
-const SUFFIX_PATTERN = /([\w-_]+)[-_]\w+\.jsx?$/;
-const DIRECTORY_PATTERN = /([\w-_]+)\/\w+\.jsx?$/;
+const SUFFIX_PATTERN = /([\w-_]+)[-_]\w+\.[a-z]+$/;
+const DIRECTORY_PATTERN = /([\w-_]+)\/\w+\.[a-z]+$/;
 
 export default function getComponentNameFromFileName(fileName) {
   const match = fileName.match(SUFFIX_PATTERN) || fileName.match(DIRECTORY_PATTERN);

--- a/test/getComponentNameFromFileName-test.js
+++ b/test/getComponentNameFromFileName-test.js
@@ -8,6 +8,14 @@ it('handles directory structures', () => {
   expect(getComponentNameFromFileName('./src/Button/happo.jsx')).toEqual('Button');
 });
 
+it('handles ts files', () => {
+  expect(getComponentNameFromFileName('./src/Button/happo.ts')).toEqual('Button');
+});
+
+it('handles tsx files', () => {
+  expect(getComponentNameFromFileName('/foo/bar/Car/happo.tsx')).toEqual('Car');
+});
+
 it('handles directory structures with unconventional names', () => {
   expect(getComponentNameFromFileName('./src/foo_bar/happo.jsx')).toEqual('foo_bar');
 });


### PR DESCRIPTION
I noticed a project with very long component names. I hadn't properly
taken typescript into account.